### PR TITLE
feat(gwapp): update chart for MQTT config and queue

### DIFF
--- a/charts/gateway-app/Chart.yaml
+++ b/charts/gateway-app/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.0.2-self"
+appVersion: "0.1.0"

--- a/charts/gateway-app/templates/deployment.yaml
+++ b/charts/gateway-app/templates/deployment.yaml
@@ -51,23 +51,37 @@ spec:
           #     port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-          {{- with .Values.volumeMounts }}
           volumeMounts:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
+            - name: dev
+              mountPath: /dev
+            - name: mqtt-config
+              mountPath: {{ .Values.mqttConfigPath }}
+            - name: mqtt-file-queue
+              mountPath: {{ .Values.mqttFileQueuePath }}
+            - name: mqtt-file-store
+              mountPath: {{ .Values.mqttFileStorePath }}
           env:
-            - name: "HOST_USERNAME"
-              value: {{ .Values.hostUsername }}
-            - name: "HOST_PASSWORD"
-              value: {{ .Values.hostPassword }}
-            - name: "HOST_ADDRESS"
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.hostIP
-      {{- with .Values.volumes }}
+            - name: MQTT_CONFIG_PATH
+              value: {{ .Values.mqttConfigPath }}
+            - name: MQTT_FILE_QUEUE_PATH
+              value: {{ .Values.mqttFileQueuePath }}
+            - name: MQTT_FILE_STORE_PATH
+              value: {{ .Values.mqttFileStorePath }}
       volumes:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+        - name: dev
+          hostPath:
+            path: /dev
+        - name: mqtt-config
+          hostPath:
+            path: {{ .Values.mqttConfigPath }}
+        - name: mqtt-file-queue
+          hostPath:
+            path: {{ .Values.mqttFileQueuePath }}
+            type: DirectoryOrCreate
+        - name: mqtt-file-store
+          hostPath:
+            path: {{ .Values.mqttFileStorePath }}
+            type: DirectoryOrCreate
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/gateway-app/templates/deployment.yaml
+++ b/charts/gateway-app/templates/deployment.yaml
@@ -54,15 +54,17 @@ spec:
           volumeMounts:
             - name: dev
               mountPath: /dev
-            - name: mqtt-config
-              mountPath: {{ .Values.mqttConfigPath }}
-            - name: mqtt-file-queue
+            - name: mqtt
+              mountPath: {{ .Values.mqttPath }}
+            - name: mqtt
               mountPath: {{ .Values.mqttFileQueuePath }}
-            - name: mqtt-file-store
+              subPath: {{ .Values.mqttFileQueueSubPath }}
+            - name: mqtt
               mountPath: {{ .Values.mqttFileStorePath }}
+              subPath: {{ .Values.mqttFileStoreSubPath }}
           env:
-            - name: MQTT_CONFIG_PATH
-              value: {{ .Values.mqttConfigPath }}
+            - name: MQTT_DIR_PATH
+              value: {{ .Values.mqttPath }}
             - name: MQTT_FILE_QUEUE_PATH
               value: {{ .Values.mqttFileQueuePath }}
             - name: MQTT_FILE_STORE_PATH
@@ -71,16 +73,10 @@ spec:
         - name: dev
           hostPath:
             path: /dev
-        - name: mqtt-config
+            type: Directory
+        - name: mqtt
           hostPath:
-            path: {{ .Values.mqttConfigPath }}
-        - name: mqtt-file-queue
-          hostPath:
-            path: {{ .Values.mqttFileQueuePath }}
-            type: DirectoryOrCreate
-        - name: mqtt-file-store
-          hostPath:
-            path: {{ .Values.mqttFileStorePath }}
+            path: {{ .Values.mqttPath }}
             type: DirectoryOrCreate
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/gateway-app/values.yaml
+++ b/charts/gateway-app/values.yaml
@@ -109,6 +109,8 @@ affinity: {}
 
 #
 
-mqttConfigPath: /var/run/glassdome-gateway/mqtt/config
+mqttPath: /var/run/glassdome-gateway/mqtt
 mqttFileQueuePath: /var/run/glassdome-gateway/mqtt/queue
 mqttFileStorePath: /var/run/glassdome-gateway/mqtt/store
+mqttFileQueueSubPath: queue
+mqttFileStoreSubPath: store

--- a/charts/gateway-app/values.yaml
+++ b/charts/gateway-app/values.yaml
@@ -94,13 +94,6 @@ volumes:
   - name: dev
     hostPath:
       path: /dev
-  - name: dbus
-    hostPath:
-      path: /var/run/dbus
-  - name: secret
-    hostPath:
-      path: /usr/local/lib/auth
-      type: DirectoryOrCreate
 
 # Additional volumeMounts on the output Deployment definition.
 volumeMounts:
@@ -109,10 +102,6 @@ volumeMounts:
   #   readOnly: true
   - name: dev
     mountPath: /dev
-  - name: dbus
-    mountPath: /var/run/dbus
-  - name: secret
-    mountPath: /ko-app/auth
 
 nodeSelector: {}
 

--- a/charts/gateway-app/values.yaml
+++ b/charts/gateway-app/values.yaml
@@ -88,41 +88,27 @@ autoscaling:
 
 # Additional volumes on the output Deployment definition.
 volumes:
+  []
   # - name: foo
   #   secret:
   #     secretName: mysecret
   #     optional: false
-  - name: dev
-    hostPath:
-      path: /dev
-  - name: mqtt-config
-    hostPath:
-      path: /var/run/glassdome-gateway/mqtt/config
-  - name: mqtt-file-queue
-    hostPath:
-      path: /var/run/glassdome-gateway/mqtt/queue
-      type: DirectoryOrCreate
-  - name: mqtt-file-store
-    hostPath:
-      path: /var/run/glassdome-gateway/mqtt/store
-      type: DirectoryOrCreate
 
 # Additional volumeMounts on the output Deployment definition.
 volumeMounts:
+  []
   # - name: foo
   #   mountPath: "/etc/foo"
   #   readOnly: true
-  - name: dev
-    mountPath: /dev
-  - name: mqtt-config
-    mountPath: /var/run/glassdome-gateway/mqtt/config
-  - name: mqtt-file-queue
-    mountPath: /var/run/glassdome-gateway/mqtt/queue
-  - name: mqtt-file-store
-    mountPath: /var/run/glassdome-gateway/mqtt/store
 
 nodeSelector: {}
 
 tolerations: []
 
 affinity: {}
+
+#
+
+mqttConfigPath: /var/run/glassdome-gateway/mqtt/config
+mqttFileQueuePath: /var/run/glassdome-gateway/mqtt/queue
+mqttFileStorePath: /var/run/glassdome-gateway/mqtt/store

--- a/charts/gateway-app/values.yaml
+++ b/charts/gateway-app/values.yaml
@@ -10,7 +10,8 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
-imagePullSecrets: []
+imagePullSecrets:
+  - name: glassdomedev
 nameOverride: ""
 fullnameOverride: ""
 
@@ -94,6 +95,17 @@ volumes:
   - name: dev
     hostPath:
       path: /dev
+  - name: mqtt-config
+    hostPath:
+      path: /var/run/glassdome-gateway/mqtt/config
+  - name: mqtt-file-queue
+    hostPath:
+      path: /var/run/glassdome-gateway/mqtt/queue
+      type: DirectoryOrCreate
+  - name: mqtt-file-store
+    hostPath:
+      path: /var/run/glassdome-gateway/mqtt/store
+      type: DirectoryOrCreate
 
 # Additional volumeMounts on the output Deployment definition.
 volumeMounts:
@@ -102,6 +114,12 @@ volumeMounts:
   #   readOnly: true
   - name: dev
     mountPath: /dev
+  - name: mqtt-config
+    mountPath: /var/run/glassdome-gateway/mqtt/config
+  - name: mqtt-file-queue
+    mountPath: /var/run/glassdome-gateway/mqtt/queue
+  - name: mqtt-file-store
+    mountPath: /var/run/glassdome-gateway/mqtt/store
 
 nodeSelector: {}
 


### PR DESCRIPTION
This PR is for making gateway app to be able to use MQTT config file downloaded by console and MQTT file queue.

We decided not to manage network from gateway app, so related volumes and envs were deleted.

TD-877